### PR TITLE
Get username

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -42,19 +42,17 @@ def verify():
     return jsonify(user)
 
 
-@app.route('/<user_id>', methods=['POST'])
-def get_username(user_id):
-    if len(user_id) > 2 and user_id[0:2] == 'fb':
-        user_id = user_id[2:]
+@app.route('/username', methods=['POST'])
+def get_username():
     auth = request.headers.get('Authorization').strip().split(',')
     tokens = validate_header_parts(auth)
     if 'access_token' not in tokens:
         raise_exception(message='Only Facebook users must retrieve their usernames separately from their user')
-    resp = requests.get('https://graph.facebook.com/%s' % (user_id,), headers={'Accept': 'application/json'})
+    resp = requests.get('https://graph.facebook.com/me?access_token=%s' % (tokens['access_token'],), headers={'Accept': 'application/json'})
     user = resp.json()
-    if 'username' not in user:
-        raise_exception(message='Invalid user ID specified for Facebook user')
-    return user['username']
+    if 'name' not in user:
+        raise_exception(message='Invalid Facebook user specified')
+    return jsonify({'username': user['name']})
 
 
 def validate_header_parts(components):


### PR DESCRIPTION
Ability to get a username for a given access token corresponding to a valid facebook user. This is necessary because usernames don't come back in the primary request to validate the access token the first time. This second request should only be done once and that is the first time that they sign in.
